### PR TITLE
Fix Create User tests

### DIFF
--- a/McGillMart.ump
+++ b/McGillMart.ump
@@ -8,7 +8,7 @@ class McGillMart
 class User
 {
   Integer id;
-  unique String email;
+  String email;
   String name;
   String password;
   String phoneNumber;

--- a/McGillMart/McGillMart/src/main/java/com/mcgillmart/McGillMart/model/User.java
+++ b/McGillMart/McGillMart/src/main/java/com/mcgillmart/McGillMart/model/User.java
@@ -88,19 +88,8 @@ public class User
   public boolean setEmail(String aEmail)
   {
     boolean wasSet = false;
-    String anOldEmail = getEmail();
-    if (anOldEmail != null && anOldEmail.equals(aEmail)) {
-      return true;
-    }
-    if (hasWithEmail(aEmail)) {
-      return wasSet;
-    }
-    email = aEmail;
+    email = aEmail.toLowerCase();
     wasSet = true;
-    if (anOldEmail != null) {
-      usersByEmail.remove(anOldEmail);
-    }
-    usersByEmail.put(aEmail, this);
     return wasSet;
   }
 
@@ -136,16 +125,6 @@ public class User
   public String getEmail()
   {
     return email;
-  }
-  /* Code from template attribute_GetUnique */
-  public static User getWithEmail(String aEmail)
-  {
-    return usersByEmail.get(aEmail);
-  }
-  /* Code from template attribute_HasUnique */
-  public static boolean hasWithEmail(String aEmail)
-  {
-    return getWithEmail(aEmail) != null;
   }
 
   public String getName()

--- a/McGillMart/McGillMart/src/test/java/com/mcgillmart/McGillMart/features/ViewUserProfileStepDefinitions.java
+++ b/McGillMart/McGillMart/src/test/java/com/mcgillmart/McGillMart/features/ViewUserProfileStepDefinitions.java
@@ -1,4 +1,4 @@
-/* package com.mcgillmart.McGillMart.features;
+package com.mcgillmart.McGillMart.features;
 
 import com.mcgillmart.McGillMart.model.User;
 import com.mcgillmart.McGillMart.services.UserService;
@@ -32,16 +32,14 @@ public class ViewUserProfileStepDefinitions {
                     userMap.get("email"),
                     userMap.get("name"),
                     userMap.get("password"),
-                    userMap.get("phoneNumber"),
-                    null,  // ShoppingCart not initialized here
-                    null   // McGillMart association not handled in this step
+                    userMap.get("phoneNumber"), 
+                    null
             );
             userService.createUser(
                     user.getEmail(),
                     user.getName(),
                     user.getPassword(),
-                    user.getPhoneNumber(),
-                    0 // assuming default shopping cart ID for simplicity
+                    user.getPhoneNumber()
             );
         }
     }
@@ -82,4 +80,3 @@ public class ViewUserProfileStepDefinitions {
         assertEquals(errorMessage, caughtException.getMessage());
     }
 }
- */


### PR DESCRIPTION
- Change UMP, so the user email is not set to unique, it is unique but it is handle directly by us when creating user. Else it would cause issue with duplicate.
- Fix the create user tests they are now all passing
- I fix one of the update test as an example of what should be mocked